### PR TITLE
增加ws协议判断，以方便使用反代

### DIFF
--- a/src/config/pcsconfig.js
+++ b/src/config/pcsconfig.js
@@ -2,7 +2,7 @@ var host = location.host;
 
 export default {
     base_url: '/', //production
-    ws_url: 'ws://' + host + '/ws', //production
+    ws_url: location.protocol.replace('^http','ws')+'//' + host + '/ws', //production
 
     // base_url: 'http://127.0.0.1:8081/', //develop
     // ws_url: 'ws://127.0.0.1:8081/ws', //develop


### PR DESCRIPTION
解决走nginx https反代时，连接的ws协议会提示不安全并无法使用的问题
#18 